### PR TITLE
Inputvalidierung fakultativ

### DIFF
--- a/mgdm2oereb_service/config/mgdm2oereb.yml
+++ b/mgdm2oereb_service/config/mgdm2oereb.yml
@@ -211,6 +211,16 @@ Mgdm2OerebTransformator:
       metadata: None
       keywords:
         - message
+    input_validation:
+      title: Input Validation
+      description: "Switch to enable input validation (default: False)"
+      schema:
+        type: boolean
+      minOccurs: 0
+      maxOccurs: 1
+      metadata: None
+      keywords:
+        - message
   outputs:
     result:
       title: Transformed XTF File

--- a/mgdm2oereb_service/src/mgdm2oereb_service/pygeoapi_plugins/process/mgdm2oereb/processors.py
+++ b/mgdm2oereb_service/src/mgdm2oereb_service/pygeoapi_plugins/process/mgdm2oereb/processors.py
@@ -15,6 +15,7 @@ class Mgdm2OerebTransformator(Mgdm2OerebTransformatorBase):
         theme_code = data.get('theme_code', None)
         model_name = data.get('model_name', None)
         catalog = data.get('catalog', None)
+        input_validation = data.get('input_validation', False) in [True, 'true', 1, '1', 'True']
         result = {
             "theme_code": theme_code,
             "target_basket_id": target_basket_id
@@ -87,20 +88,21 @@ class Mgdm2OerebTransformator(Mgdm2OerebTransformatorBase):
         except Exception as e:
             result.update({'error': e})
             return mimetype, result
-        input_validation_failed, input_validation_result = self.validate(
-            input_xtf_content,
-            self.ilivalidator_service_url,
-            self.result_xtf_file_name,
-            all_objects_accessible=False
-        )
-        input_log_file_path = input_log_file.save_runtime_file(
-            input_validation_result
-        )
-        input_log_file.save_result_file(input_validation_result)
-        result.update({"input_validation_log": f"/{RESULTS_PATH}/{input_log_file.file_name()}"})
-        if input_validation_failed:
-            result.update({'error': 'Validation of input file failed.'})
-            return mimetype, result
+        if input_validation:
+            input_validation_failed, input_validation_result = self.validate(
+                input_xtf_content,
+                self.ilivalidator_service_url,
+                self.result_xtf_file_name,
+                all_objects_accessible=False
+            )
+            input_log_file_path = input_log_file.save_runtime_file(
+                input_validation_result
+            )
+            input_log_file.save_result_file(input_validation_result)
+            result.update({"input_validation_log": f"/{RESULTS_PATH}/{input_log_file.file_name()}"})
+            if input_validation_failed:
+                result.update({'error': 'Validation of input file failed.'})
+                return mimetype, result
 
         xsl_trafo_path = os.path.join(
             self.mgdm2oereb_xsl_path,
@@ -191,6 +193,9 @@ class Mgdm2OerebTransformator(Mgdm2OerebTransformatorBase):
 
 
 class Mgdm2OerebTransformatorOereblex(Mgdm2OerebTransformatorBase):
+
+    # TODO: Implement switch "input_validation": true as parameter like it is implemented in the non oereblex
+    # trafo
 
     def __init__(self, processor_def):
 


### PR DESCRIPTION
Inputvalidierung ist nun standardmässig deaktiviert. Kann aber per Jobparameter angeschaltet werden: `"input_validation": true` (standardmässig `false` muss also nicht explizit deaktiviert werden).

Beispielparameter

```json
{
  "inputs": {
    "zip_file": "...",
    "theme_code": "ch.Laermempfindlichkeitsstufen",
    "target_basket_id": "ch.tha.Laermempfindlichkeitsstufen",
    "model_name": "Laermempfindlichkeitsstufen_V1_2",
    "catalog": "https://models.geo.sh.ch/AGI/OeREB/ch.sh.OeREBKRMlegdrst_V2_0.xml",
    "input_validation": true
  }
}
```